### PR TITLE
Add client implementation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,8 @@
+The MIT License (MIT)
+
+Copyright (c) 2020 Simon Eisenmann
 Copyright (c) 2015 Jan Berktold
+Copyright (c) 2015 Andrew Stuart
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,9 +1,60 @@
 # Server-sent events for Go
 [![GoDoc](https://godoc.org/github.com/longsleep/sse?status.svg)](https://godoc.org/github.com/longsleep/sse)
 
-This is a lightweight SEE library for Golang which is designed to play nicely along different packages and provide a convient usage. Compatible with every Go version since 1.1.
+This is a lightweight SEE client and server library for Golang which is designed
+to play nicely along different packages and provide a convient usage. Compatible
+with every Go version since 1.1.
 
-## Examples
+## Client usage
+
+```go
+import (
+	"github.com/longsleep/sse"
+)
+```
+
+```go
+var Client = &http.Client{}
+```
+Client is the default client used for requests.
+
+```go
+var (
+	//ErrNilChan will be returned by Notify if it is passed a nil channel
+	ErrNilChan = fmt.Errorf("nil channel given")
+)
+```
+
+```go
+var GetReq = func(verb, uri string, body io.Reader) (*http.Request, error) {
+	return http.NewRequest(verb, uri, body)
+}
+```
+GetReq is a function to return a single request. It will be used by notify to
+get a request and can be replaces if additional configuration is desired on the
+request. The "Accept" header will necessarily be overwritten.
+
+```go
+func Notify(uri string, evCh chan<- *Event) error
+```
+Notify takes the uri of an SSE stream and channel, and will send an Event down
+the channel when recieved, until the stream is closed. It will then close the
+stream. This is blocking, and so you will likely want to call this in a new
+goroutine (via `go Notify(..)`)
+
+### type Event
+
+```go
+type Event struct {
+	URI  string
+	Type string
+	Data io.Reader
+}
+```
+
+Event is a go representation of an http server-sent event
+
+## Server Examples
 
 *Note:* Also look into the examples folder.
 
@@ -103,3 +154,12 @@ func main() {
 }
 
 ```
+
+## Acknowledgements
+
+This project is a combination of two see libraries:
+
+- https://github.com/andrewstuart/go-sse/ (client)
+- https://github.com/JanBerktold/sse (server)
+
+Thank you!

--- a/client.go
+++ b/client.go
@@ -1,0 +1,101 @@
+package sse
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+var (
+	// ErrNilChan will be returned by Notify if it is passed a nil channel
+	ErrNilChan = fmt.Errorf("nil channel given")
+)
+
+// Client is the default client used for requests.
+var Client = &http.Client{}
+
+func makeReqest(method, uri string, body io.Reader) (*http.Request, error) {
+	req, err := GetReq(method, uri, body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", sseContentType)
+
+	return req, nil
+}
+
+// Event is a go representation of an http server-sent event
+type Event struct {
+	URI  string
+	Type string
+	Data io.Reader
+}
+
+// GetReq is a function to return a single request. It will be used by notify to
+// get a request and can be replaced if additional configuration is desired on
+// the request. The "Accept" header will necessarily be overwritten.
+var GetReq = func(method, uri string, body io.Reader) (*http.Request, error) {
+	return http.NewRequest(method, uri, body)
+}
+
+// Notify takes the uri of an SSE stream and channel, and will send an Event
+// down the channel when recieved, until the stream is closed. It will then
+// close the stream. This is blocking, and so you will likely want to call this
+// in a new goroutine (via `go Notify(..)`)
+func Notify(uri string, evCh chan<- *Event) error {
+	if evCh == nil {
+		return ErrNilChan
+	}
+
+	req, err := makeReqest(http.MethodGet, uri, nil)
+	if err != nil {
+		return fmt.Errorf("error getting sse request: %v", err)
+	}
+
+	res, err := Client.Do(req)
+	if err != nil {
+		return fmt.Errorf("error performing sse request for %s: %v", uri, err)
+	}
+
+	br := bufio.NewReader(res.Body)
+	defer res.Body.Close()
+
+	delim := []byte{':', ' '}
+
+	var currEvent *Event
+
+	for {
+		bs, err := br.ReadBytes('\n')
+
+		if err != nil && err != io.EOF {
+			return err
+		}
+
+		if len(bs) < 2 {
+			continue
+		}
+
+		spl := bytes.Split(bs, delim)
+
+		if len(spl) < 2 {
+			continue
+		}
+
+		currEvent = &Event{URI: uri}
+		switch string(spl[0]) {
+		case keyEvent:
+			currEvent.Type = string(bytes.TrimSpace(spl[1]))
+		case keyData:
+			currEvent.Data = bytes.NewBuffer(bytes.TrimSpace(spl[1]))
+			evCh <- currEvent
+		}
+		if err == io.EOF {
+			break
+		}
+	}
+
+	return nil
+}

--- a/examples/events/main.go
+++ b/examples/events/main.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
-	"github.com/longsleep/sse"
 	"net/http"
 	"time"
+
+	"github.com/longsleep/sse"
 )
 
 func HandleSSE(w http.ResponseWriter, r *http.Request) {
@@ -33,5 +34,5 @@ func main() {
 		http.ServeFile(w, r, "main.html")
 	})
 
-	http.ListenAndServe(":80", nil)
+	http.ListenAndServe(":8080", nil)
 }

--- a/examples/time/main.go
+++ b/examples/time/main.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
-	"github.com/longsleep/sse"
 	"net/http"
 	"time"
+
+	"github.com/longsleep/sse"
 )
 
 func HandleSSE(w http.ResponseWriter, r *http.Request) {
@@ -35,5 +36,5 @@ func main() {
 		http.ServeFile(w, r, "main.html")
 	})
 
-	http.ListenAndServe(":80", nil)
+	http.ListenAndServe(":8080", nil)
 }


### PR DESCRIPTION
This adds a sse client to to this library as found in
github.com/andrewstuart/go-sse with MIT license to avoid
cluttering server and client implementations all over the place and to
prepare for future development here.

So this library is now essentially a merge between
github.com/JanBerktold/sse and github.com/andrewstuart/go-sse.